### PR TITLE
allows to api returns empty responses, and keep key "data" in json respo...

### DIFF
--- a/simpleapi/__init__.py
+++ b/simpleapi/__init__.py
@@ -70,15 +70,17 @@ def api_handler(func):
         except SimpleHttpException:
             e = sys.exc_info()[1]
             code = create_exception_response(request, e.message, e.error_slug, e.code, e.info)
+            data = None
         except Exception:
             logger.exception('caught an unhandled exception in %s', func)
             code = create_exception_response(request, 'Unhandled Exception', 'unhandled', 500, None)
+            data = None
 
         resp_envelope = {
             'meta': get_meta(request, code)
         }
 
-        if data:
+        if data is not None:
             resp_envelope['data'] = data
 
         pp = request.META.get('HTTP_X_PRETTY_PRINT_JSON', '0') == '1'

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -16,6 +16,18 @@ class SimpleApiTestCase(TestCase):
         self.assertEquals(result['meta']['code'], 200)
         self.assertEquals(result['data']['value'], True)
 
+    def test_empty_resp(self):
+        resp = self.client.get('/empty_response_test')
+        self.assertEquals(resp.status_code, 200)
+
+        result = json.loads(resp.content)
+
+        self.assertIn('meta', result)
+        self.assertIn('data', result)
+        self.assertIn('code', result['meta'])
+        self.assertEquals(result['meta']['code'], 200)
+        self.assertEquals(result['data'], [])
+
     def test_bad_response(self):
         resp = self.client.get('/test2')
         self.assertEquals(resp.status_code, 400)

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -8,5 +8,6 @@ urlpatterns = patterns(
     url(r'^test1$', views.resp_test),
     url(r'^test2$', views.resp_test2),
     url(r'^test3$', views.resp_test3),
+    url(r'^empty_response_test$', views.empty_response_test),
     url(r'^api/v1/', include(simple_api_patterns)),
 )

--- a/tests/views.py
+++ b/tests/views.py
@@ -17,6 +17,9 @@ def resp_test2(request):
         'value': True
     }
 
+@api_handler
+def empty_response_test(request):
+    return []
 
 @api_handler
 def resp_test3(request):


### PR DESCRIPTION
When api returns empty result keep key 'data' in json response. 
