### PR TITLE
functools.wrap used in api_handler decorator to allow getting docstrings

### DIFF
--- a/simpleapi/__init__.py
+++ b/simpleapi/__init__.py
@@ -9,6 +9,8 @@ from django.conf.urls import patterns, url
 from django.core.urlresolvers import RegexURLResolver
 from django.views.decorators.csrf import csrf_exempt
 
+from functools import wraps
+
 from .utils import CaseInsensitiveDict
 
 logger = logging.getLogger(__name__)
@@ -60,6 +62,7 @@ def get_meta(request, code):
 
 
 def api_handler(func):
+    @wraps(func)
     def inner(request, *args, **kwargs):
         request.META['_simple_api_meta'] = request.META.get('_simple_api_meta', dict())
         data = None

--- a/tests/tests.py
+++ b/tests/tests.py
@@ -1,6 +1,7 @@
 import json
 
 from django.test import TestCase
+from simpleapi import url_patterns
 
 
 class SimpleApiTestCase(TestCase):
@@ -27,6 +28,12 @@ class SimpleApiTestCase(TestCase):
         self.assertIn('code', result['meta'])
         self.assertEquals(result['meta']['code'], 200)
         self.assertEquals(result['data'], [])
+
+    def test_dockstring_view_docstring(self):
+        """Testing that decorated view returns valid dockstring, before @wraps it always was None"""
+        from views import docstring_test as docstring_test_view
+
+        self.assertEquals(docstring_test_view.__doc__, "Docstring description")
 
     def test_bad_response(self):
         resp = self.client.get('/test2')

--- a/tests/urls.py
+++ b/tests/urls.py
@@ -9,5 +9,6 @@ urlpatterns = patterns(
     url(r'^test2$', views.resp_test2),
     url(r'^test3$', views.resp_test3),
     url(r'^empty_response_test$', views.empty_response_test),
+    url(r'^docstring_test$', views.docstring_test),
     url(r'^api/v1/', include(simple_api_patterns)),
 )

--- a/tests/views.py
+++ b/tests/views.py
@@ -21,6 +21,13 @@ def resp_test2(request):
 def empty_response_test(request):
     return []
 
+@api_handler 
+def docstring_test(request):
+    """Docstring description"""
+    return "Dockstring response"
+
+
+
 @api_handler
 def resp_test3(request):
 
@@ -42,4 +49,5 @@ def resp_export_test1(request, param):
     return {
         'value': param
     }
+
 


### PR DESCRIPTION
view.**doc** was None for all views decorated with api_handler, i put there @functiontools.wrap, and now it returns .**doc**. 

I want to use it for autodocumenting api 
